### PR TITLE
kewords VIS and T3 takes string values instead of booleans. list of String constants

### DIFF
--- a/src/main/java/fr/jmmc/oitools/image/ImageOiInputParam.java
+++ b/src/main/java/fr/jmmc/oitools/image/ImageOiInputParam.java
@@ -38,11 +38,19 @@ public final class ImageOiInputParam extends ImageOiParam {
     private final static KeywordMeta KEYWORD_TARGET = new KeywordMeta(ImageOiConstants.KEYWORD_TARGET, "Identifier of the target object to reconstruct", Types.TYPE_CHAR);
     private final static KeywordMeta KEYWORD_WAVE_MIN = new KeywordMeta(ImageOiConstants.KEYWORD_WAVE_MIN, "Minimum wavelength to select (in meters)", Types.TYPE_DBL);
     private final static KeywordMeta KEYWORD_WAVE_MAX = new KeywordMeta(ImageOiConstants.KEYWORD_WAVE_MAX, "Maximum wavelength to select (in meters)", Types.TYPE_DBL);
-// TODO: value can be: ’NONE’, ’ALL’, ’AMP’ or ’PHI’ (string)
-    private final static KeywordMeta KEYWORD_USE_VIS = new KeywordMeta(ImageOiConstants.KEYWORD_USE_VIS, "Use complex visibility data if any", Types.TYPE_LOGICAL);
+    // value can be: ’NONE’, ’ALL’, ’AMP’ or ’PHI’ (string)
+    private final static KeywordMeta KEYWORD_USE_VIS = new KeywordMeta(
+            ImageOiConstants.KEYWORD_USE_VIS, "Use complex visibility data if any", Types.TYPE_CHAR);
     private final static KeywordMeta KEYWORD_USE_VIS2 = new KeywordMeta(ImageOiConstants.KEYWORD_USE_VIS2, "Use squared visibility data if any", Types.TYPE_LOGICAL);
-// TODO: value can be: ’NONE’, ’ALL’, ’AMP’ or ’PHI’ (string)
-    private final static KeywordMeta KEYWORD_USE_T3 = new KeywordMeta(ImageOiConstants.KEYWORD_USE_T3, "Use triple product data if any", Types.TYPE_LOGICAL);
+    // value can be: ’NONE’, ’ALL’, ’AMP’ or ’PHI’ (string)
+    private final static KeywordMeta KEYWORD_USE_T3 = new KeywordMeta(
+            ImageOiConstants.KEYWORD_USE_T3, "Use triple product data if any", Types.TYPE_CHAR);
+
+    public final static String VIS2_T3_NONE = "NONE";
+    public final static String VIS2_T3_ALL = "ALL";
+    public final static String VIS2_T3_AMP = "AMP";
+    public final static String VIS2_T3_PHI = "PHI";
+    public final static String[] VIS2_T3_VALUES = new String[]{VIS2_T3_NONE, VIS2_T3_ALL, VIS2_T3_AMP, VIS2_T3_PHI};
 
     // Define Algorithm settings keywords
     // TODO init-img keyword could be checked like OIDATA.INSNAME or OIDATA.ARRNAME to be sure that one or more HDUs are present with this name.
@@ -151,12 +159,12 @@ public final class ImageOiInputParam extends ImageOiParam {
         setKeywordDouble(ImageOiConstants.KEYWORD_WAVE_MAX, wave_max);
     }
 
-    public boolean useVis() {
-        return getKeywordLogical(ImageOiConstants.KEYWORD_USE_VIS);
+    public String useVis() {
+        return getKeyword(ImageOiConstants.KEYWORD_USE_VIS);
     }
 
-    public void useVis(boolean use_vis) {
-        setKeywordLogical(ImageOiConstants.KEYWORD_USE_VIS, use_vis);
+    public void useVis(String use_vis) {
+        setKeyword(ImageOiConstants.KEYWORD_USE_VIS, use_vis);
     }
 
     public boolean useVis2() {
@@ -167,12 +175,12 @@ public final class ImageOiInputParam extends ImageOiParam {
         setKeywordLogical(ImageOiConstants.KEYWORD_USE_VIS2, use_vis2);
     }
 
-    public boolean useT3() {
-        return getKeywordLogical(ImageOiConstants.KEYWORD_USE_T3);
+    public String useT3() {
+        return getKeyword(ImageOiConstants.KEYWORD_USE_T3);
     }
 
-    public void useT3(boolean use_t3) {
-        setKeywordLogical(ImageOiConstants.KEYWORD_USE_T3, use_t3);
+    public void useT3(String use_t3) {
+        setKeyword(ImageOiConstants.KEYWORD_USE_T3, use_t3);
     }
 
     public String getInitImg() {

--- a/src/main/java/fr/jmmc/oitools/model/OIFitsLoader.java
+++ b/src/main/java/fr/jmmc/oitools/model/OIFitsLoader.java
@@ -827,44 +827,4 @@ public class OIFitsLoader {
         return oiFitsFile;
     }
 
-    /**
-     * Fix the given OIFitsFile: correct errors now fixed but still present in lots of old files.
-     * For example, the input param USE_VIS was erroneously typed Logical before. Now it has been
-     * changed to type Char, but a lot of old files needs to be changed to be correctly understood by the tools.
-     *
-     * @param oiFitsFile the OIFitsFile to fix
-     * @return true if changed something. false if nothing was changed.
-     */
-    public static boolean fixOIFitsFile(final OIFitsFile oiFitsFile) {
-
-        boolean changedSomething = false;
-
-        // change USE_VIS and USE_T3 from old erroneous logical type to char type
-        // "T" becomes "ALL" and "F" becomes "NONE"
-
-        final ImageOiInputParam inputParams = oiFitsFile.getImageOiData().getInputParam();
-
-        String useVIS = inputParams.getKeyword(ImageOiConstants.KEYWORD_USE_VIS);
-        if (useVIS != null) {
-            if ("T".equals(useVIS)) {
-                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_VIS, ImageOiInputParam.VIS2_T3_ALL);
-                changedSomething = true;
-            } else if ("F".equals(useVIS)) {
-                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_VIS, ImageOiInputParam.VIS2_T3_NONE);
-                changedSomething = true;
-            }
-        }
-        String useT3 = inputParams.getKeyword(ImageOiConstants.KEYWORD_USE_T3);
-        if (useT3 != null) {
-            if ("T".equals(useT3)) {
-                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_T3, ImageOiInputParam.VIS2_T3_ALL);
-                changedSomething = true;
-            } else if ("F".equals(useT3)) {
-                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_T3, ImageOiInputParam.VIS2_T3_NONE);
-                changedSomething = true;
-            }
-        }
-
-        return changedSomething;
-    }
 }

--- a/src/main/java/fr/jmmc/oitools/model/OIFitsLoader.java
+++ b/src/main/java/fr/jmmc/oitools/model/OIFitsLoader.java
@@ -30,6 +30,7 @@ import fr.jmmc.oitools.image.FitsImageHDUFactory;
 import fr.jmmc.oitools.image.FitsImageLoader;
 import fr.jmmc.oitools.image.ImageOiConstants;
 import fr.jmmc.oitools.image.ImageOiData;
+import fr.jmmc.oitools.image.ImageOiInputParam;
 import fr.jmmc.oitools.meta.ArrayColumnMeta;
 import fr.jmmc.oitools.meta.ColumnMeta;
 import fr.jmmc.oitools.meta.OIFitsStandard;
@@ -826,4 +827,44 @@ public class OIFitsLoader {
         return oiFitsFile;
     }
 
+    /**
+     * Fix the given OIFitsFile: correct errors now fixed but still present in lots of old files.
+     * For example, the input param USE_VIS was erroneously typed Logical before. Now it has been
+     * changed to type Char, but a lot of old files needs to be changed to be correctly understood by the tools.
+     *
+     * @param oiFitsFile the OIFitsFile to fix
+     * @return true if changed something. false if nothing was changed.
+     */
+    public static boolean fixOIFitsFile(final OIFitsFile oiFitsFile) {
+
+        boolean changedSomething = false;
+
+        // change USE_VIS and USE_T3 from old erroneous logical type to char type
+        // "T" becomes "ALL" and "F" becomes "NONE"
+
+        final ImageOiInputParam inputParams = oiFitsFile.getImageOiData().getInputParam();
+
+        String useVIS = inputParams.getKeyword(ImageOiConstants.KEYWORD_USE_VIS);
+        if (useVIS != null) {
+            if ("T".equals(useVIS)) {
+                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_VIS, ImageOiInputParam.VIS2_T3_ALL);
+                changedSomething = true;
+            } else if ("F".equals(useVIS)) {
+                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_VIS, ImageOiInputParam.VIS2_T3_NONE);
+                changedSomething = true;
+            }
+        }
+        String useT3 = inputParams.getKeyword(ImageOiConstants.KEYWORD_USE_T3);
+        if (useT3 != null) {
+            if ("T".equals(useT3)) {
+                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_T3, ImageOiInputParam.VIS2_T3_ALL);
+                changedSomething = true;
+            } else if ("F".equals(useT3)) {
+                inputParams.setKeyword(ImageOiConstants.KEYWORD_USE_T3, ImageOiInputParam.VIS2_T3_NONE);
+                changedSomething = true;
+            }
+        }
+
+        return changedSomething;
+    }
 }


### PR DESCRIPTION
Associated to OImaging issue https://github.com/JMMC-OpenDev/oimaging/issues/18

- reset constants about USE_VIS and USE_T3
- add a function to fix old oifits file to change boolean USE_VIS value to String value